### PR TITLE
Fix hip-runtime-nvidia post installation script

### DIFF
--- a/packaging/hip-runtime-nvidia.postinst
+++ b/packaging/hip-runtime-nvidia.postinst
@@ -19,9 +19,9 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 
-ROCMDIR=@ROCM_PATH@
-HIPDIR=$ROCMDIR/hip
+ROCMDIR="@ROCM_PATH@"
+HIPDIR="$ROCMDIR/hip"
 
-if [ -d $ROCMDIR] ; then
-    ln -s -f $ROCMDIR /opt/rocm
+if [ -d "$ROCMDIR" ] ; then
+    ln -s -f "$ROCMDIR" /opt/rocm
 fi


### PR DESCRIPTION
Without this fix installing hip-runtime-nvidia fails with the following error:
```
/var/lib/dpkg/info/hip-runtime-nvidia.postinst: line 25: [: missing `]'
```